### PR TITLE
Add support for model hotkey requests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+token
+./venv

--- a/vtspy.py
+++ b/vtspy.py
@@ -91,4 +91,75 @@ class VTSClient:
         response = json.loads(self.instance.recv())
         return response
 
+    def request_folder_info(self, request_id: str = ""):
+        payload = {
+            "apiName": "VTubeStudioPublicAPI",
+            "apiVersion": "1.0",
+            "requestID": request_id,
+            "messageType": "VTSFolderInfoRequest"
+        }
+
+        self.instance.send(json.dumps(payload))
+        response = json.loads(self.instance.recv())
+        return response
+
+    def request_current_model(self, request_id: str = ""):
+        payload = {
+            "apiName": "VTubeStudioPublicAPI",
+            "apiVersion": "1.0",
+            "requestID": request_id,
+            "messageType": "CurrentModelRequest"
+        }
+
+        self.instance.send(json.dumps(payload))
+        response = json.loads(self.instance.recv())
+        return response
+
+    def request_available_models(self, request_id: str = ""):
+        payload = {
+            "apiName": "VTubeStudioPublicAPI",
+            "apiVersion": "1.0",
+            "requestID": request_id,
+            "messageType": "AvailableModelsRequest"
+        }
+
+        self.instance.send(json.dumps(payload))
+        response = json.loads(self.instance.recv())
+        return response
+
+    def load_model(self, model_id: str, request_id: str = ""):
+        payload = {
+            "apiName": "VTubeStudioPublicAPI",
+            "apiVersion": "1.0",
+            "requestID": request_id,
+            "messageType": "ModelLoadRequest",
+            "data": {
+                "modelID": model_id
+            }
+        }
+
+        self.instance.send(json.dumps(payload))
+        response = json.loads(self.instance.recv())
+        return response
+
+    def move_model_request(self, time_in_seconds: float, values_are_relative_to_model: bool, x_pos: float = None, y_pos: float = None, rotation: float = None, size: float = None, request_id: str = ""):
+        payload = {
+            "apiName": "VTubeStudioPublicAPI",
+            "apiVersion": "1.0",
+            "requestID": request_id,
+            "messageType": "MoveModelRequest",
+            "data": {
+                "timeInSeconds": time_in_seconds,
+                "valuesAreRelativeToModel": values_are_relative_to_model,
+                "positionX": x_pos,
+                "positionY": y_pos,
+                "rotation": rotation,
+                "size": size
+            }
+        }
+
+        self.instance.send(json.dumps(payload))
+        response = json.loads(self.instance.recv())
+        return response
+
 

--- a/vtspy.py
+++ b/vtspy.py
@@ -162,4 +162,74 @@ class VTSClient:
         response = json.loads(self.instance.recv())
         return response
 
+    def request_current_model_hotkeys(self, request_id: str = ""):
+        payload = {
+            "apiName": "VTubeStudioPublicAPI",
+            "apiVersion": "1.0",
+            "requestID": request_id,
+            "messageType": "HotkeysInCurrentModelRequest"
+        }
 
+        self.instance.send(json.dumps(payload))
+        response = json.loads(self.instance.recv())
+        return response
+
+    def request_model_hotkeys_by_id(self, model_id: str, request_id: str = ""):
+        payload = {
+            "apiName": "VTubeStudioPublicAPI",
+            "apiVersion": "1.0",
+            "requestID": request_id,
+            "messageType": "HotkeysInCurrentModelRequest",
+            "data": {
+                "modelID": model_id
+            }
+        }
+
+        self.instance.send(json.dumps(payload))
+        response = json.loads(self.instance.recv())
+        return response
+
+    # Currently not working
+    # Nothing is received but in the logs for VTube Studio it says that there was a NullReferenceException: Object reference not set to an instance of an object.
+    # def request_live2d_item_hotkeys(self, item_file_name, request_id: str = ""):
+    #     payload = {
+    #         "apiName": "VTubeStudioPublicAPI",
+    #         "apiVersion": "1.0",
+    #         "requestID": request_id,
+    #         "messageType": "HotkeysInCurrentModelRequest",
+    #         "data": {
+    #             "live2DItemFileName": item_file_name
+    #         }
+    #     }
+    #
+    #     print("requesting hotkeys for live2d item")
+    #     self.instance.send(json.dumps(payload))
+    #     print("sent request")
+    #     response = json.loads(self.instance.recv())
+    #     print(response)
+    #     return response
+
+    def request_items_list(self,
+                           include_available_spots: bool = False,
+                           include_item_instances_in_scene: bool = False,
+                           include_available_item_files: bool = False,
+                           only_items_with_file_name: str = "",
+                           only_items_with_instance_id: str = "",
+                           request_id: str = ""):
+        payload = {
+            "apiName": "VTubeStudioPublicAPI",
+            "apiVersion": "1.0",
+            "requestID": request_id,
+            "messageType": "ItemListRequest",
+            "data": {
+                "includeAvailableSpots": include_available_spots,
+                "includeItemInstancesInScene": include_item_instances_in_scene,
+                "includeAvailableItemFiles": include_available_item_files,
+                "onlyItemsWithFileName": only_items_with_file_name,
+                "onlyItemsWithInstanceID": only_items_with_instance_id
+            }
+        }
+        self.instance.send(json.dumps(payload))
+        response = json.loads(self.instance.recv())
+        print(response)
+        return response


### PR DESCRIPTION
In this branch I added full support for one more request type and partial support for one other request type.

-  I added full support for the "ItemListRequest" type. 

-  For the "HotkeysInCurrentModelRequest", I split it into three methods:
-  1. The `request_current_model_hotkeys()` method makes use of the "data" block being optional and the websocket's default return of the current model's hotkeys
-  2. The `request_model_hotkeys_by_id()` method uses the "modelID" key of the "data" object to be able to request the hotkeys of models both currently in use and not in use.
-  3. (Not working yet) The `request_live2d_item_hotkeys()` will use the "live2DItemFileName" key of the "data" object to  retrieve the hotkeys of a specific Live2D item. Currently, the request is sent, but nothing returns and the logs say that there's a NullReferenceException, and I haven't figured out why yet.